### PR TITLE
Change font size to default for tables

### DIFF
--- a/resources/views/popover-column.blade.php
+++ b/resources/views/popover-column.blade.php
@@ -34,7 +34,7 @@
     @endif
 
     <div
-        class="relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
+        class="text-sm relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
         @if($getTrigger === 'hover')
             @pointerenter="$refs.panel.open"
         @else


### PR DESCRIPTION
Changed the font size in tables to the default size for consistency and improved visual coherence. Previously, tables had varying font sizes, which led to inconsistencies in the interface.