### PR TITLE
Change font & icon size to default for tables

### DIFF
--- a/resources/views/popover-column.blade.php
+++ b/resources/views/popover-column.blade.php
@@ -34,7 +34,7 @@
     @endif
 
     <div
-        class="relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
+        class="text-sm relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
         @if($getTrigger === 'hover')
             @pointerenter="$refs.panel.open"
         @else
@@ -46,7 +46,7 @@
         @if($getIcon)
             <x-filament::icon
                 :icon="$getIcon"
-                class="h-5 w-5 text-gray-500 dark:text-gray-400"
+                class="h-4 w-4 text-gray-500 dark:text-gray-400"
             />
         @endif
     </div>

--- a/resources/views/popover-entry.blade.php
+++ b/resources/views/popover-entry.blade.php
@@ -16,7 +16,7 @@
     @endif
 >
     <div
-        class="relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
+        class="text-sm relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
         @if($getTrigger === 'hover')
             @pointerenter="$refs.panel.open"
         @else
@@ -28,7 +28,7 @@
         @if($getIcon)
             <x-filament::icon
                 :icon="$getIcon"
-                class="h-5 w-5 text-gray-500 dark:text-gray-400"
+                class="h-4 w-4 text-gray-500 dark:text-gray-400"
             />
         @endif
     </div>

--- a/resources/views/popover-form.blade.php
+++ b/resources/views/popover-form.blade.php
@@ -27,7 +27,7 @@
         @endif
     >
         <div
-            class="relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
+            class="text-sm relative w-full fi-popover-trigger cursor-pointer flex items-center gap-2"
             @if($getTrigger === 'hover')
                 @pointerenter="$refs.panel.open"
             @else


### PR DESCRIPTION
Changed the font and icons size in the tables to the default size for consistency and improved visual perception. Previously, tables had different font sizes, which led to inconsistencies in the interface.