### PR TITLE
Fixed the popover border display in dark theme

### DIFF
--- a/resources/views/popover-column.blade.php
+++ b/resources/views/popover-column.blade.php
@@ -51,7 +51,7 @@
         @endif
     </div>
 
-    <div class="z-50 fi-popover-content w-[{{ $getPopOverMaxWidth }}px] border border-gray-100 rounded-lg shadow-lg bg-white dark:bg-gray-800 transition"
+    <div class="z-50 fi-popover-content w-[{{ $getPopOverMaxWidth }}px] ring-1 ring-gray-950/5 dark:ring-white/10 rounded-lg shadow-lg bg-white dark:bg-gray-800 transition"
          x-transition:enter-start="opacity-0"
          x-transition:leave-end="opacity-0"
          x-cloak

--- a/resources/views/popover-entry.blade.php
+++ b/resources/views/popover-entry.blade.php
@@ -33,7 +33,7 @@
         @endif
     </div>
 
-    <div class="z-50 fi-popover-content w-[{{ $getPopOverMaxWidth }}px] border border-gray-100 rounded-lg shadow-lg bg-white dark:bg-gray-800 transition"
+    <div class="z-50 fi-popover-content w-[{{ $getPopOverMaxWidth }}px] ring-1 ring-gray-950/5 dark:ring-white/10 rounded-lg shadow-lg bg-white dark:bg-gray-800 transition"
          x-transition:enter-start="opacity-0"
          x-transition:leave-end="opacity-0"
          x-cloak

--- a/resources/views/popover-form.blade.php
+++ b/resources/views/popover-form.blade.php
@@ -37,7 +37,7 @@
             {{ $getState }}
         </div>
 
-        <div class="z-50 fi-popover-content w-[{{ $getPopOverMaxWidth }}px] border border-gray-100 rounded-lg shadow-lg bg-white dark:bg-gray-800"
+        <div class="z-50 fi-popover-content w-[{{ $getPopOverMaxWidth }}px] ring-1 ring-gray-950/5 dark:ring-white/10 rounded-lg shadow-lg bg-white dark:bg-gray-800"
              x-transition:enter-start="opacity-0"
              x-transition:leave-end="opacity-0"
              x-cloak


### PR DESCRIPTION
Previously, the popover border appeared white in dark theme `border border-gray-100`, which disrupted the overall styling. I updated the style to `ring-1 ring-gray-950/5 dark:ring-white/10`, ensuring the border displays correctly in both dark and light themes.


Dark theme - Before
![dark-before](https://github.com/user-attachments/assets/186274de-c80b-4841-bdb6-bfcf5bc069a1)

Dark theme - After
![dark-after](https://github.com/user-attachments/assets/6ae88184-7e55-48de-96e2-8346f7f75e35)

Light theme - Before
![before](https://github.com/user-attachments/assets/0b37eb33-76e5-45f7-a248-0219d0efe30b)

Light theme - After
![after](https://github.com/user-attachments/assets/6d753052-4af3-4b33-a728-ef8707bfa3ca)
